### PR TITLE
[fix]: 로그인/회원가입 페이지 디자인 변경 (#15)

### DIFF
--- a/app/components/PrivacyPolicyModal.tsx
+++ b/app/components/PrivacyPolicyModal.tsx
@@ -174,7 +174,7 @@ export default function PrivacyPolicyModal({
       <Modal.Footer className='ml-auto border-none'>
         <button
           onClick={() => setOpenPrivacyPolicyModal(undefined)}
-          className='text-white bg-[#3870e0] px-4 py-[0.4rem] rounded-[0.2rem] font-light focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow'
+          className='text-white bg-[#3a8af9] px-4 py-[0.4rem] rounded-md font-light focus:bg-[#1c6cdb] hover:bg-[#1c6cdb] box-shadow'
         >
           닫기
         </button>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -10,11 +10,7 @@ import logoImg from '@/public/images/logo.png';
 import { AxiosError } from 'axios';
 import Link from 'next/link';
 import PrivacyPolicyModal from '../components/PrivacyPolicyModal';
-
-interface UserLoginInfoType {
-  id: string;
-  pwd: string;
-}
+import { Label } from 'flowbite-react';
 
 // 로그인 API
 // const login = (userAccountInfo: UserLoginInfoType) => {
@@ -32,15 +28,6 @@ interface UserLoginInfoType {
 // };
 
 export default function Login() {
-  const STR_RIGHT_CASE_INPUT_ELEMENT_STYLE_CLASSNAME =
-    'block px-2.5 pb-3.5 pt-3.5 w-full text-sm text-gray-900 bg-transparent rounded-[0.2rem] border-1 border-[#d8d9dc] appearance-none dark:text-white dark:border-gray-600 dark:focus:border-blue-500 focus:outline-none focus:ring-0 focus:border-blue-600 focus:border-2 peer';
-  const STR_WRONG_CASE_INPUT_ELEMENT_STYLE_CLASSNAME =
-    'block px-2.5 pb-3.5 pt-3.5 w-full text-sm text-gray-900 bg-transparent rounded-[0.2rem] border-1 border-[#d8d9dc] appearance-none dark:text-white dark:border-gray-600 dark:focus:border-[#c84031] focus:outline-none focus:ring-0 focus:border-[#c84031] focus:border-2 peer';
-  const STR_RIGHT_CASE_LABEL_ELEMENT_STYLE_CLASSNAME =
-    'absolute text-sm text-gray-500 dark:text-gray-400 duration-150 transform -translate-y-[1.07rem] scale-75 top-2 origin-[0] bg-white dark:bg-gray-900 px-1 peer-focus:px-1 peer-focus:text-blue-500 peer-focus:dark:text-blue-500 peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-4 left-2';
-  const STR_WRONG_CASE_LABEL_ELEMENT_STYLE_CLASSNAME =
-    'absolute text-sm text-gray-500 dark:text-gray-400 duration-150 transform -translate-y-[1.07rem] scale-75 top-2 origin-[0] bg-white dark:bg-gray-900 px-1 peer-focus:px-1 peer-focus:text-[#c84031] peer-focus:dark:text-[#c84031] peer-placeholder-shown:scale-100 peer-placeholder-shown:-translate-y-1/2 peer-placeholder-shown:top-1/2 peer-focus:top-2 peer-focus:scale-75 peer-focus:-translate-y-4 left-2';
-
   // const loginMutation = useMutation({
   //   mutationFn: login,
   //   onMutate: () => {
@@ -122,21 +109,9 @@ export default function Login() {
     email: '',
     pwd: '',
   });
+  const [isPwdVisibility, setIsPwdVisibility] = useState(false);
   const [idInputAnnounceMsg, setIdInputAnnouceMsg] = useState('');
   const [pwdInputAnnounceMsg, setPwdInputAnnouceMsg] = useState('');
-  const [idInputElementStyle, setIdInputElementStyle] = useState(
-    STR_RIGHT_CASE_INPUT_ELEMENT_STYLE_CLASSNAME
-  );
-  const [idLabelElementStyle, setIdLabelElementStyle] = useState(
-    STR_RIGHT_CASE_LABEL_ELEMENT_STYLE_CLASSNAME
-  );
-  const [pwdInputElementStyle, setPwdInputElementStyle] = useState(
-    STR_RIGHT_CASE_INPUT_ELEMENT_STYLE_CLASSNAME
-  );
-  const [pwdLabelElementStyle, setPwdLabelElementStyle] = useState(
-    STR_RIGHT_CASE_LABEL_ELEMENT_STYLE_CLASSNAME
-  );
-  const [isAdjustOpacity, setIsAdjustOpacity] = useState(false);
   const [openPrivacyPolicyModal, setOpenPrivacyPolicyModal] = useState<
     string | undefined
   >();
@@ -150,184 +125,229 @@ export default function Login() {
     e.preventDefault();
     setIdInputAnnouceMsg('');
     setPwdInputAnnouceMsg('');
-    setIdInputElementStyle(STR_RIGHT_CASE_INPUT_ELEMENT_STYLE_CLASSNAME);
-    setIdLabelElementStyle(STR_RIGHT_CASE_LABEL_ELEMENT_STYLE_CLASSNAME);
-    setPwdLabelElementStyle(STR_RIGHT_CASE_INPUT_ELEMENT_STYLE_CLASSNAME);
-    setPwdLabelElementStyle(STR_RIGHT_CASE_LABEL_ELEMENT_STYLE_CLASSNAME);
 
     if (!userAccountInfo.email) {
       idInputRef.current?.focus();
       setIdInputAnnouceMsg('이메일을 입력하세요.');
-      setIdInputElementStyle(STR_WRONG_CASE_INPUT_ELEMENT_STYLE_CLASSNAME);
-      setIdLabelElementStyle(STR_WRONG_CASE_LABEL_ELEMENT_STYLE_CLASSNAME);
       return;
     }
 
     if (!userAccountInfo.pwd) {
       pwdInputRef.current?.focus();
       setPwdInputAnnouceMsg('비밀번호를 입력하세요.');
-      setPwdInputElementStyle(STR_WRONG_CASE_INPUT_ELEMENT_STYLE_CLASSNAME);
-      setPwdLabelElementStyle(STR_WRONG_CASE_LABEL_ELEMENT_STYLE_CLASSNAME);
       return;
     }
 
     // loginMutation.mutate(userAccountInfo);
+    alert('개발 예정');
   };
 
   return (
-    <div className='mt-10 h-[39rem]'>
-      <div
-        className={`w-fit 2md:w-96 p-4 mx-auto ${
-          isAdjustOpacity && 'opacity-60'
-        }`}
-      >
-        <div className='flex flex-col text-center border p-8 rounded-md border-[#d8d9dc] bg-[#fefefe] shadow-lg'>
-          <div className='flex flex-col gap-2 text-xl my-2'>
-            <Image
-              src={logoImg}
-              alt='list'
-              width={35}
-              height={0}
-              quality={100}
-              className='mx-auto mb-1'
-            />
-            <p>로그인</p>
-          </div>
+    <div className='mt-16 h-[37.5rem]'>
+      <div className='w-[22.5rem] mx-auto'>
+        <Image
+          src={logoImg}
+          alt='list'
+          width={35}
+          height={0}
+          quality={100}
+          className='mx-auto'
+        />
 
-          <form>
-            <div className='flex flex-col w-full mx-auto mt-6'>
-              <div className='relative h-12'>
-                <input
-                  type='text'
-                  id='floating_outlined'
-                  className={idInputElementStyle}
-                  value={userAccountInfo.email}
-                  ref={idInputRef}
-                  onChange={(e) =>
-                    setUserAccountInfo({
-                      ...userAccountInfo,
-                      email: e.target.value,
-                    })
-                  }
-                  placeholder=' '
-                />
-                <label
-                  htmlFor='floating_outlined'
-                  className={idLabelElementStyle}
-                >
-                  이메일
-                </label>
-              </div>
-              {idInputAnnounceMsg && (
-                <div className='flex mt-[0.3rem]'>
-                  <svg
-                    xmlns='http://www.w3.org/2000/svg'
-                    height='15'
-                    viewBox='0 -960 960 960'
-                    width='15'
-                    fill='#c84031'
-                    className='relative left-[0.1rem] top-[0.1rem]'
-                  >
-                    <path d='M479.928-274.022q16.463 0 27.398-10.743 10.935-10.743 10.935-27.206 0-16.464-10.863-27.518-10.862-11.055-27.326-11.055-16.463 0-27.398 11.037-10.935 11.037-10.935 27.501 0 16.463 10.863 27.224 10.862 10.76 27.326 10.76Zm-30.993-158.739h68.13v-257.065h-68.13v257.065Zm31.364 358.74q-84.202 0-158.041-31.879t-129.159-87.199q-55.32-55.32-87.199-129.201-31.878-73.88-31.878-158.167t31.878-158.2q31.879-73.914 87.161-128.747 55.283-54.832 129.181-86.818 73.899-31.986 158.205-31.986 84.307 0 158.249 31.968 73.942 31.967 128.756 86.768 54.815 54.801 86.79 128.883 31.976 74.083 31.976 158.333 0 84.235-31.986 158.07t-86.818 128.942q-54.833 55.107-128.873 87.169-74.04 32.063-158.242 32.063Z' />
-                  </svg>
-                  <p
-                    id='helper-checkbox-text'
-                    className='relative pr-2 left-[0.5rem] w-full text-left text-xs font-normal text-[#c84031] dark:text-gray-300'
-                  >
-                    {idInputAnnounceMsg}
-                  </p>
-                </div>
-              )}
+        <div className='grid grid-cols-1 mt-3 text-center'>
+          <h1 className='text-[1.7rem] leading-[1.75] font-bold'>로그인</h1>
+          <p className='text-[#6a6c73]'>버디에 오신 걸 환영해요</p>
+        </div>
 
-              <div className='relative h-12 mt-5'>
-                <input
-                  type='password'
-                  id='floating_outlined'
-                  className={pwdInputElementStyle}
-                  value={userAccountInfo.pwd}
-                  ref={pwdInputRef}
-                  onChange={(e) => {
-                    setUserAccountInfo({
-                      ...userAccountInfo,
-                      pwd: e.target.value,
-                    });
-                  }}
-                  placeholder=' '
-                />
-                <label
-                  htmlFor='floating_outlined'
-                  className={pwdLabelElementStyle}
-                >
-                  비밀번호 입력
-                </label>
-              </div>
-              {pwdInputAnnounceMsg && (
-                <div className='flex mt-[0.3rem] mb-1'>
-                  <svg
-                    xmlns='http://www.w3.org/2000/svg'
-                    height='15'
-                    viewBox='0 -960 960 960'
-                    width='15'
-                    fill='#c84031'
-                    className='relative left-[0.1rem] top-[0.1rem]'
-                  >
-                    <path d='M479.928-274.022q16.463 0 27.398-10.743 10.935-10.743 10.935-27.206 0-16.464-10.863-27.518-10.862-11.055-27.326-11.055-16.463 0-27.398 11.037-10.935 11.037-10.935 27.501 0 16.463 10.863 27.224 10.862 10.76 27.326 10.76Zm-30.993-158.739h68.13v-257.065h-68.13v257.065Zm31.364 358.74q-84.202 0-158.041-31.879t-129.159-87.199q-55.32-55.32-87.199-129.201-31.878-73.88-31.878-158.167t31.878-158.2q31.879-73.914 87.161-128.747 55.283-54.832 129.181-86.818 73.899-31.986 158.205-31.986 84.307 0 158.249 31.968 73.942 31.967 128.756 86.768 54.815 54.801 86.79 128.883 31.976 74.083 31.976 158.333 0 84.235-31.986 158.07t-86.818 128.942q-54.833 55.107-128.873 87.169-74.04 32.063-158.242 32.063Z' />
-                  </svg>
-                  <p
-                    id='helper-checkbox-text'
-                    className='relative pr-2 left-[0.5rem] w-full text-left text-xs font-normal text-[#c84031] dark:text-gray-300'
-                  >
-                    {pwdInputAnnounceMsg}
-                  </p>
-                </div>
-              )}
+        <form className='flex max-w-md flex-col mt-10'>
+          <div className='relative'>
+            <div className='mb-1'>
+              <Label
+                htmlFor='email'
+                value='이메일'
+                className={`text-[#a2a4a9] text-[0.5rem] leading-[1] font-light`}
+              />
             </div>
-            <div className='h-36 flex flex-col mt-[0.625rem] justify-between text-left mb-6'>
-              <a
-                href='https://sw7up.cbnu.ac.kr/account/password'
-                target='_blank'
-                className='text-[#437ae1] text-[0.8rem] font-semibold w-fit'
+            <input
+              required
+              placeholder='abc@naver.com'
+              type='text'
+              value={userAccountInfo.email}
+              onChange={(e) =>
+                setUserAccountInfo({
+                  ...userAccountInfo,
+                  email: e.target.value,
+                })
+              }
+              className={`placeholder-[#9ea3ae] rounded-[0.425rem] border border-${
+                idInputAnnounceMsg ? 'red-500' : '[#d4d5d7]'
+              } text-sm font-light w-full focus:ring-0 py-3 ${
+                userAccountInfo.email && 'pr-[2.5rem]'
+              }`}
+            />
+            {userAccountInfo.email && (
+              <button
+                className='absolute top-[2.05rem] right-3 p-1'
+                onClick={(e) => {
+                  e.preventDefault();
+                  setUserAccountInfo({
+                    ...userAccountInfo,
+                    email: '',
+                  });
+                }}
               >
-                비밀번호를 잊으셨나요?
-              </a>
-              <div className='text-[0.8rem] text-gray-600'>
-                내 컴퓨터가 아닌가요? 시크릿 모드를 사용하여 비공개로
-                로그인하세요.
-              </div>
-              <div className='flex justify-between items-center'>
-                <Link
-                  href='/register'
-                  className='text-[#437ae1] translate-x-[-0.5rem] text-[0.8rem] font-normal px-2 py-1 hover:bg-[#f3f4f5] rounded-[0rem] focus:bg-[#f3f4f5]'
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  height='22'
+                  viewBox='0 -960 960 960'
+                  width='22'
+                  fill='#a2a4a9'
                 >
-                  계정 만들기
-                </Link>
-                <button
-                  type='submit'
-                  onClick={handleSignIn}
-                  className='text-[#f9fafb] bg-[#3a8af9] px-4 py-[0.5rem] rounded-[6px] focus:bg-[#1c6cdb] hover:bg-[#1c6cdb]'
+                  <path d='M480-437.847 277.076-234.924q-8.307 8.308-20.884 8.5-12.576.193-21.268-8.5-8.693-8.692-8.693-21.076t8.693-21.076L437.847-480 234.924-682.924q-8.308-8.307-8.5-20.884-.193-12.576 8.5-21.268 8.692-8.693 21.076-8.693t21.076 8.693L480-522.153l202.924-202.923q8.307-8.308 20.884-8.5 12.576-.193 21.268 8.5 8.693 8.692 8.693 21.076t-8.693 21.076L522.153-480l202.923 202.924q8.308 8.307 8.5 20.884.193 12.576-8.5 21.268-8.692 8.693-21.076 8.693t-21.076-8.693L480-437.847Z' />
+                </svg>
+              </button>
+            )}
+            {idInputAnnounceMsg && (
+              <div className='flex mt-[0.3rem]'>
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  height='15'
+                  viewBox='0 -960 960 960'
+                  width='15'
+                  fill='#c84031'
+                  className='relative left-[0.1rem] top-[0.1rem]'
                 >
-                  로그인
-                </button>
+                  <path d='M479.928-274.022q16.463 0 27.398-10.743 10.935-10.743 10.935-27.206 0-16.464-10.863-27.518-10.862-11.055-27.326-11.055-16.463 0-27.398 11.037-10.935 11.037-10.935 27.501 0 16.463 10.863 27.224 10.862 10.76 27.326 10.76Zm-30.993-158.739h68.13v-257.065h-68.13v257.065Zm31.364 358.74q-84.202 0-158.041-31.879t-129.159-87.199q-55.32-55.32-87.199-129.201-31.878-73.88-31.878-158.167t31.878-158.2q31.879-73.914 87.161-128.747 55.283-54.832 129.181-86.818 73.899-31.986 158.205-31.986 84.307 0 158.249 31.968 73.942 31.967 128.756 86.768 54.815 54.801 86.79 128.883 31.976 74.083 31.976 158.333 0 84.235-31.986 158.07t-86.818 128.942q-54.833 55.107-128.873 87.169-74.04 32.063-158.242 32.063Z' />
+                </svg>
+                <p
+                  id='helper-checkbox-text'
+                  className='relative pr-2 left-[0.5rem] w-full text-left text-xs font-normal text-[#c84031] dark:text-gray-300'
+                >
+                  {idInputAnnounceMsg}
+                </p>
               </div>
+            )}
+          </div>
+          <div className='mt-4 relative'>
+            <div className='mt-1'>
+              <Label
+                htmlFor='password'
+                value='비밀번호'
+                className={`text-[#a2a4a9] text-[0.5rem] leading-[1] font-light`}
+              />
             </div>
-          </form>
-          <div>
-            <div date-rangepicker='true' className='flex items-center'>
-              <div className='relative'></div>
+            <input
+              required
+              placeholder='비밀번호를 입력해 주세요'
+              type={isPwdVisibility ? 'text' : 'password'}
+              value={userAccountInfo.pwd}
+              onChange={(e) => {
+                setUserAccountInfo({
+                  ...userAccountInfo,
+                  pwd: e.target.value,
+                });
+              }}
+              className={`placeholder-[#9ea3ae] rounded-[0.425rem] border border-${
+                pwdInputAnnounceMsg ? 'red-500' : '[#d4d5d7]'
+              } text-sm font-light w-full focus:ring-0 py-3 ${
+                userAccountInfo.pwd && 'pr-[2.5rem]'
+              }`}
+            />
+            {userAccountInfo.pwd && (
+              <button
+                className='absolute top-[2.05rem] right-3 p-1'
+                onClick={(e) => {
+                  e.preventDefault();
+                  setIsPwdVisibility((prev) => !prev);
+                }}
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  height='22'
+                  viewBox='0 -960 960 960'
+                  width='22'
+                  fill='#a2a4a9'
+                >
+                  {isPwdVisibility ? (
+                    <path d='M480.091-336.924q67.985 0 115.485-47.59 47.5-47.591 47.5-115.577 0-67.985-47.59-115.485-47.591-47.5-115.577-47.5-67.985 0-115.485 47.59-47.5 47.591-47.5 115.577 0 67.985 47.59 115.485 47.591 47.5 115.577 47.5ZM480-392q-45 0-76.5-31.5T372-500q0-45 31.5-76.5T480-608q45 0 76.5 31.5T588-500q0 45-31.5 76.5T480-392Zm.055 171.999q-137.977 0-251.439-76.115Q115.155-372.231 61.54-500q53.615-127.769 167.022-203.884 113.406-76.115 251.383-76.115t251.439 76.115Q844.845-627.769 898.46-500q-53.615 127.769-167.022 203.884-113.406 76.115-251.383 76.115ZM480-500Zm0 220q113 0 207.5-59.5T832-500q-50-101-144.5-160.5T480-720q-113 0-207.5 59.5T128-500q50 101 144.5 160.5T480-280Z' />
+                  ) : (
+                    <path d='M630.922-441.078 586-486q9-49.693-28.346-89.346Q520.307-615 466-606l-44.922-44.922q13.538-6.077 27.769-9.115 14.23-3.039 31.153-3.039 68.076 0 115.576 47.5T643.076-500q0 16.923-3.039 31.538-3.038 14.615-9.115 27.384Zm127.231 124.462L714-358q38-29 67.5-63.5T832-500q-50-101-143.5-160.5T480-720q-29 0-57 4t-55 12l-46.614-46.614q37.923-15.077 77.461-22.231 39.538-7.154 81.153-7.154 140.615 0 253.614 77.538 113 77.539 164.846 202.461-22.231 53.615-57.423 100.076-35.192 46.461-82.884 83.308Zm32.308 231.383L628.616-245.848q-30.769 11.385-68.192 18.616Q523-220.001 480-220.001q-140.999 0-253.614-77.538Q113.771-375.078 61.54-500q22.154-53 57.231-98.885 35.077-45.884 77.231-79.576l-110.77-112 42.154-42.153 705.228 705.228-42.153 42.153ZM238.155-636.309q-31.692 25.231-61.654 60.655Q146.539-540.231 128-500q50 101 143.5 160.5T480-280q27.308 0 54.386-4.616 27.077-4.615 45.923-9.538l-50.616-51.847q-10.231 4.153-23.693 6.615-13.461 2.462-26 2.462-68.076 0-115.576-47.5T316.924-500q0-12.154 2.462-25.423 2.462-13.27 6.615-24.27l-87.846-86.616ZM541-531Zm-131.768 65.769Z' />
+                  )}
+                </svg>
+              </button>
+            )}
+            {pwdInputAnnounceMsg && (
+              <div className='flex mt-[0.3rem] mb-1'>
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  height='15'
+                  viewBox='0 -960 960 960'
+                  width='15'
+                  fill='#c84031'
+                  className='relative left-[0.1rem] top-[0.1rem]'
+                >
+                  <path d='M479.928-274.022q16.463 0 27.398-10.743 10.935-10.743 10.935-27.206 0-16.464-10.863-27.518-10.862-11.055-27.326-11.055-16.463 0-27.398 11.037-10.935 11.037-10.935 27.501 0 16.463 10.863 27.224 10.862 10.76 27.326 10.76Zm-30.993-158.739h68.13v-257.065h-68.13v257.065Zm31.364 358.74q-84.202 0-158.041-31.879t-129.159-87.199q-55.32-55.32-87.199-129.201-31.878-73.88-31.878-158.167t31.878-158.2q31.879-73.914 87.161-128.747 55.283-54.832 129.181-86.818 73.899-31.986 158.205-31.986 84.307 0 158.249 31.968 73.942 31.967 128.756 86.768 54.815 54.801 86.79 128.883 31.976 74.083 31.976 158.333 0 84.235-31.986 158.07t-86.818 128.942q-54.833 55.107-128.873 87.169-74.04 32.063-158.242 32.063Z' />
+                </svg>
+                <p
+                  id='helper-checkbox-text'
+                  className='relative pr-2 left-[0.5rem] w-full text-left text-xs font-normal text-[#c84031] dark:text-gray-300'
+                >
+                  {pwdInputAnnounceMsg}
+                </p>
+              </div>
+            )}
+          </div>
+
+          <p className='text-[0.8rem] leading-[1rem] text-blue-500 mt-2'>
+            비밀번호를 잊으셨나요?
+          </p>
+
+          <button
+            type='submit'
+            onClick={handleSignIn}
+            disabled={
+              userAccountInfo.email && userAccountInfo.pwd ? false : true
+            }
+            className={`mt-12 px-4 py-[0.75rem] rounded-[0.425rem] box-shadow font-medium ${
+              userAccountInfo.email && userAccountInfo.pwd
+                ? 'text-white bg-[#3a8af9] hover:bg-[#1c6cdb]'
+                : 'text-white bg-[#bfc0c4]'
+            }`}
+          >
+            로그인 하기
+          </button>
+
+          <div className='flex justify-between gap-x-1 mt-3'>
+            <div>
+              <span className='text-[#6a6c73] text-[0.8rem] leading-[1rem]'>
+                버디를 처음 이용하시나요?{' '}
+              </span>
+              <Link
+                href='/register'
+                className='text-blue-500 text-[0.8rem] leading-[1rem] hover:underline'
+              >
+                회원가입
+              </Link>
+            </div>
+            <div>
+              <button
+                onClick={(e) => {
+                  e.preventDefault();
+                  setOpenPrivacyPolicyModal('default');
+                }}
+                className='text-[#6a6c73] text-[0.5rem] leading-[1] hover:text-black'
+              >
+                개인정보처리방침
+              </button>
+              {openPrivacyPolicyModal ? (
+                <PrivacyPolicyModal
+                  openPrivacyPolicyModal={openPrivacyPolicyModal}
+                  setOpenPrivacyPolicyModal={setOpenPrivacyPolicyModal}
+                />
+              ) : null}
             </div>
           </div>
-        </div>
-        <div className='flex mt-5 text-[0.6rem] text-gray-700 justify-end'>
-          <button onClick={() => setOpenPrivacyPolicyModal('default')}>
-            개인정보처리방침
-          </button>
-          {openPrivacyPolicyModal ? (
-            <PrivacyPolicyModal
-              openPrivacyPolicyModal={openPrivacyPolicyModal}
-              setOpenPrivacyPolicyModal={setOpenPrivacyPolicyModal}
-            />
-          ) : null}
-        </div>
+        </form>
       </div>
     </div>
   );

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -3,16 +3,22 @@
 import React, { FormEvent, useState } from 'react';
 import PrivacyPolicyModal from '../components/PrivacyPolicyModal';
 import { Label } from 'flowbite-react';
+import Link from 'next/link';
 
 export default function Register() {
   const [email, setEmail] = useState('');
-  const [isEmailValidFail, setIsEmailValidFail] = useState(false);
   const [password, setPassword] = useState('');
-  const [isPasswordValidFail, setIsPasswordValidFail] = useState(false);
+  const [isPwdVisibility, setIsPwdVisibility] = useState(false);
   const [repeatPassword, setRepeatPassword] = useState('');
+  const [isRepeatPwdVisibility, setIsRepeatPwdVisibility] = useState(false);
+  useState(false);
+  const [username, setUsername] = useState('');
+  const [isChckedPrivacyPolicy, setIsChckedPrivacyPolicy] = useState(false);
+
+  const [isEmailValidFail, setIsEmailValidFail] = useState(false);
+  const [isPasswordValidFail, setIsPasswordValidFail] = useState(false);
   const [isRepeatPasswordValidFail, setIsRepeatPasswordValidFail] =
     useState(false);
-  const [username, setUsername] = useState('');
   const [isUsernameValidFail, setIsUsernameValidFail] = useState(false);
   const [openPrivacyPolicyModal, setOpenPrivacyPolicyModal] = useState<
     string | undefined
@@ -78,18 +84,36 @@ export default function Register() {
   };
 
   return (
-    <div className='h-[35.5rem] mt-12 px-5 2lg:px-0 overflow-x-auto'>
-      <div className='flex flex-col w-[20rem] mx-auto'>
+    <div className='h-[42.5rem] mt-10 px-5 2lg:px-0 overflow-x-auto'>
+      <div className='relative flex flex-col w-[20rem] mx-auto'>
+        <Link href='/login' className='absolute left-[-7.5rem]'>
+          <svg
+            xmlns='http://www.w3.org/2000/svg'
+            height='50'
+            viewBox='0 -960 960 960'
+            width='50'
+            fill='#a2a4a9'
+          >
+            <path d='m404.308-480 169.846 169.846q5.615 5.615 6 13.769.385 8.154-6 14.539T560-275.461q-7.769 0-14.154-6.385L370.308-457.385q-5.231-5.23-7.347-10.692-2.115-5.461-2.115-11.923t2.115-11.923q2.116-5.462 7.347-10.692l175.538-175.539q5.615-5.615 13.769-6 8.154-.385 14.539 6T580.539-664q0 7.769-6.385 14.154L404.308-480Z' />
+          </svg>
+        </Link>
+        <div className='grid grid-cols-1'>
+          <h1 className='text-[1.7rem] leading-[1.75] font-bold'>회원가입</h1>
+          <p className='text-[#6a6c73]'>
+            버디에 오신 것을 환영해요, 먼저 계정을 생성해 볼까요?
+          </p>
+        </div>
+
         <form
           onSubmit={handleFormSubmit}
-          className='flex max-w-md flex-col gap-4'
+          className='flex max-w-md flex-col gap-4 mt-10'
         >
-          <div>
-            <div className='mb-2 block'>
+          <div className='relative'>
+            <div className='mb-1'>
               <Label
                 htmlFor='email'
                 value='이메일'
-                className={`after:content-['*'] after:text-red-500 after:ml-[0.05rem]`}
+                className={`text-[#a2a4a9] text-[0.5rem] leading-[1] font-light`}
               />
             </div>
             <input
@@ -97,53 +121,120 @@ export default function Register() {
               type='text'
               value={email}
               onChange={handleEmailChange}
-              className={`placeholder-[#b6b7bf] bg-[#f9fafb rounded-md border border-${
-                isEmailValidFail ? 'red-500' : '[#828283]'
-              } w-full`}
+              className={`placeholder-[#9ea3ae] rounded-[0.425rem] border border-${
+                isEmailValidFail ? 'red-500' : '[#d4d5d7]'
+              } text-sm font-light w-full focus:ring-0 py-3 ${
+                email && 'pr-[2.5rem]'
+              }`}
             />
+            {email && (
+              <button
+                className='absolute top-[2.05rem] right-3 p-1'
+                onClick={(e) => {
+                  e.preventDefault();
+                  setEmail('');
+                }}
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  height='22'
+                  viewBox='0 -960 960 960'
+                  width='22'
+                  fill='#a2a4a9'
+                >
+                  <path d='M480-437.847 277.076-234.924q-8.307 8.308-20.884 8.5-12.576.193-21.268-8.5-8.693-8.692-8.693-21.076t8.693-21.076L437.847-480 234.924-682.924q-8.308-8.307-8.5-20.884-.193-12.576 8.5-21.268 8.692-8.693 21.076-8.693t21.076 8.693L480-522.153l202.924-202.923q8.307-8.308 20.884-8.5 12.576-.193 21.268 8.5 8.693 8.692 8.693 21.076t-8.693 21.076L522.153-480l202.923 202.924q8.308 8.307 8.5 20.884.193 12.576-8.5 21.268-8.692 8.693-21.076 8.693t-21.076-8.693L480-437.847Z' />
+                </svg>
+              </button>
+            )}
           </div>
-          <div>
-            <div className='mb-2 block'>
+          <div className='relative'>
+            <div className='mb-1'>
               <Label
                 htmlFor='password'
                 value='비밀번호'
-                className={`after:content-['*'] after:text-red-500 after:ml-[0.05rem]`}
+                className={`text-[#a2a4a9] text-[0.5rem] leading-[1] font-light`}
               />
             </div>
             <input
               required
-              type='password'
+              type={isPwdVisibility ? 'text' : 'password'}
               value={password}
               onChange={handlePasswordChange}
-              className={`placeholder-[#b6b7bf] bg-[#f9fafb rounded-md border border-${
-                isPasswordValidFail ? 'red-500' : '[#828283]'
-              } w-full`}
+              className={`rounded-[0.425rem] border border-${
+                isPasswordValidFail ? 'red-500' : '[#d4d5d7]'
+              } text-sm font-light w-full focus:ring-0 py-3`}
             />
+            {password && (
+              <button
+                className='absolute top-[2.05rem] right-3 p-1'
+                onClick={(e) => {
+                  e.preventDefault();
+                  setIsPwdVisibility((prev) => !prev);
+                }}
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  height='22'
+                  viewBox='0 -960 960 960'
+                  width='22'
+                  fill='#a2a4a9'
+                >
+                  {isPwdVisibility ? (
+                    <path d='M480.091-336.924q67.985 0 115.485-47.59 47.5-47.591 47.5-115.577 0-67.985-47.59-115.485-47.591-47.5-115.577-47.5-67.985 0-115.485 47.59-47.5 47.591-47.5 115.577 0 67.985 47.59 115.485 47.591 47.5 115.577 47.5ZM480-392q-45 0-76.5-31.5T372-500q0-45 31.5-76.5T480-608q45 0 76.5 31.5T588-500q0 45-31.5 76.5T480-392Zm.055 171.999q-137.977 0-251.439-76.115Q115.155-372.231 61.54-500q53.615-127.769 167.022-203.884 113.406-76.115 251.383-76.115t251.439 76.115Q844.845-627.769 898.46-500q-53.615 127.769-167.022 203.884-113.406 76.115-251.383 76.115ZM480-500Zm0 220q113 0 207.5-59.5T832-500q-50-101-144.5-160.5T480-720q-113 0-207.5 59.5T128-500q50 101 144.5 160.5T480-280Z' />
+                  ) : (
+                    <path d='M630.922-441.078 586-486q9-49.693-28.346-89.346Q520.307-615 466-606l-44.922-44.922q13.538-6.077 27.769-9.115 14.23-3.039 31.153-3.039 68.076 0 115.576 47.5T643.076-500q0 16.923-3.039 31.538-3.038 14.615-9.115 27.384Zm127.231 124.462L714-358q38-29 67.5-63.5T832-500q-50-101-143.5-160.5T480-720q-29 0-57 4t-55 12l-46.614-46.614q37.923-15.077 77.461-22.231 39.538-7.154 81.153-7.154 140.615 0 253.614 77.538 113 77.539 164.846 202.461-22.231 53.615-57.423 100.076-35.192 46.461-82.884 83.308Zm32.308 231.383L628.616-245.848q-30.769 11.385-68.192 18.616Q523-220.001 480-220.001q-140.999 0-253.614-77.538Q113.771-375.078 61.54-500q22.154-53 57.231-98.885 35.077-45.884 77.231-79.576l-110.77-112 42.154-42.153 705.228 705.228-42.153 42.153ZM238.155-636.309q-31.692 25.231-61.654 60.655Q146.539-540.231 128-500q50 101 143.5 160.5T480-280q27.308 0 54.386-4.616 27.077-4.615 45.923-9.538l-50.616-51.847q-10.231 4.153-23.693 6.615-13.461 2.462-26 2.462-68.076 0-115.576-47.5T316.924-500q0-12.154 2.462-25.423 2.462-13.27 6.615-24.27l-87.846-86.616ZM541-531Zm-131.768 65.769Z' />
+                  )}
+                </svg>
+              </button>
+            )}
           </div>
-          <div>
-            <div className='mb-2 block'>
+          <div className='relative'>
+            <div className='mb-1'>
               <Label
                 htmlFor='repeat-password'
                 value='비밀번호 확인'
-                className={`after:content-['*'] after:text-red-500 after:ml-[0.05rem]`}
+                className={`text-[#a2a4a9] text-[0.5rem] leading-[1] font-light`}
               />
             </div>
             <input
               required
-              type='password'
+              type={isRepeatPwdVisibility ? 'text' : 'password'}
               value={repeatPassword}
               onChange={handleRepeatPasswordChange}
-              className={`placeholder-[#b6b7bf] bg-[#f9fafb rounded-md border border-${
-                isRepeatPasswordValidFail ? 'red-500' : '[#828283]'
-              } w-full`}
+              className={`rounded-[0.425rem] border border-${
+                isRepeatPasswordValidFail ? 'red-500' : '[#d4d5d7]'
+              } text-sm font-light w-full focus:ring-0 py-3`}
             />
+            {repeatPassword && (
+              <button
+                className='absolute top-[2.05rem] right-3 p-1'
+                onClick={(e) => {
+                  e.preventDefault();
+                  setIsRepeatPwdVisibility((prev) => !prev);
+                }}
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  height='22'
+                  viewBox='0 -960 960 960'
+                  width='22'
+                  fill='#a2a4a9'
+                >
+                  {isRepeatPwdVisibility ? (
+                    <path d='M480.091-336.924q67.985 0 115.485-47.59 47.5-47.591 47.5-115.577 0-67.985-47.59-115.485-47.591-47.5-115.577-47.5-67.985 0-115.485 47.59-47.5 47.591-47.5 115.577 0 67.985 47.59 115.485 47.591 47.5 115.577 47.5ZM480-392q-45 0-76.5-31.5T372-500q0-45 31.5-76.5T480-608q45 0 76.5 31.5T588-500q0 45-31.5 76.5T480-392Zm.055 171.999q-137.977 0-251.439-76.115Q115.155-372.231 61.54-500q53.615-127.769 167.022-203.884 113.406-76.115 251.383-76.115t251.439 76.115Q844.845-627.769 898.46-500q-53.615 127.769-167.022 203.884-113.406 76.115-251.383 76.115ZM480-500Zm0 220q113 0 207.5-59.5T832-500q-50-101-144.5-160.5T480-720q-113 0-207.5 59.5T128-500q50 101 144.5 160.5T480-280Z' />
+                  ) : (
+                    <path d='M630.922-441.078 586-486q9-49.693-28.346-89.346Q520.307-615 466-606l-44.922-44.922q13.538-6.077 27.769-9.115 14.23-3.039 31.153-3.039 68.076 0 115.576 47.5T643.076-500q0 16.923-3.039 31.538-3.038 14.615-9.115 27.384Zm127.231 124.462L714-358q38-29 67.5-63.5T832-500q-50-101-143.5-160.5T480-720q-29 0-57 4t-55 12l-46.614-46.614q37.923-15.077 77.461-22.231 39.538-7.154 81.153-7.154 140.615 0 253.614 77.538 113 77.539 164.846 202.461-22.231 53.615-57.423 100.076-35.192 46.461-82.884 83.308Zm32.308 231.383L628.616-245.848q-30.769 11.385-68.192 18.616Q523-220.001 480-220.001q-140.999 0-253.614-77.538Q113.771-375.078 61.54-500q22.154-53 57.231-98.885 35.077-45.884 77.231-79.576l-110.77-112 42.154-42.153 705.228 705.228-42.153 42.153ZM238.155-636.309q-31.692 25.231-61.654 60.655Q146.539-540.231 128-500q50 101 143.5 160.5T480-280q27.308 0 54.386-4.616 27.077-4.615 45.923-9.538l-50.616-51.847q-10.231 4.153-23.693 6.615-13.461 2.462-26 2.462-68.076 0-115.576-47.5T316.924-500q0-12.154 2.462-25.423 2.462-13.27 6.615-24.27l-87.846-86.616ZM541-531Zm-131.768 65.769Z' />
+                  )}
+                </svg>
+              </button>
+            )}
           </div>
-          <div>
-            <div className='mb-2 block'>
+          <div className='relative'>
+            <div className='mb-1'>
               <Label
                 htmlFor='username'
                 value='이름'
-                className={`after:content-['*'] after:text-red-500 after:ml-[0.05rem]`}
+                className={`text-[#a2a4a9] text-[0.5rem] leading-[1] font-light`}
               />
             </div>
             <input
@@ -151,21 +242,43 @@ export default function Register() {
               type='text'
               value={username}
               onChange={handleUsernameChange}
-              className={`placeholder-[#b6b7bf] bg-[#f9fafb rounded-md border border-${
-                isUsernameValidFail ? 'red-500' : '[#828283]'
-              } w-full`}
+              className={`rounded-[0.425rem] border border-${
+                isUsernameValidFail ? 'red-500' : '[#d4d5d7]'
+              } text-sm font-light w-full focus:ring-0 py-3`}
             />
+            {username && (
+              <button
+                className='absolute top-[2.05rem] right-3 p-1'
+                onClick={(e) => {
+                  e.preventDefault();
+                  setUsername('');
+                }}
+              >
+                <svg
+                  xmlns='http://www.w3.org/2000/svg'
+                  height='22'
+                  viewBox='0 -960 960 960'
+                  width='22'
+                  fill='#a2a4a9'
+                >
+                  <path d='M480-437.847 277.076-234.924q-8.307 8.308-20.884 8.5-12.576.193-21.268-8.5-8.693-8.692-8.693-21.076t8.693-21.076L437.847-480 234.924-682.924q-8.308-8.307-8.5-20.884-.193-12.576 8.5-21.268 8.692-8.693 21.076-8.693t21.076 8.693L480-522.153l202.924-202.923q8.307-8.308 20.884-8.5 12.576-.193 21.268 8.5 8.693 8.692 8.693 21.076t-8.693 21.076L522.153-480l202.923 202.924q8.308 8.307 8.5 20.884.193 12.576-8.5 21.268-8.692 8.693-21.076 8.693t-21.076-8.693L480-437.847Z' />
+                </svg>
+              </button>
+            )}
           </div>
 
-          <div className='flex items-center  text-xs'>
+          <div className='flex items-center text-xs mt-[-0.25rem]'>
             <input
               type='checkbox'
-              className='rounded-[0.2rem] text-sm'
+              className='w-[0.825rem] h-[0.825rem] rounded-[0.2rem] text-sm'
               required
-              onChange={(e) => null}
+              onChange={() => setIsChckedPrivacyPolicy((prev) => !prev)}
             />
-            <button className='text-cyan-600 hover:underline dark:text-cyan-500 ml-2'>
-              <span onClick={() => setOpenPrivacyPolicyModal('default')}>
+            <button className='ml-1'>
+              <span
+                onClick={() => setOpenPrivacyPolicyModal('default')}
+                className='text-[#6a6c73] text-[0.5rem] leading-[1] hover:text-black'
+              >
                 개인정보 수집 및 이용
               </span>
               {openPrivacyPolicyModal ? (
@@ -175,11 +288,30 @@ export default function Register() {
                 />
               ) : null}
             </button>
-            <span>에 동의합니다</span>
+            <span className='text-[#6a6c73] text-[0.5rem] leading-[1]'>
+              에 동의합니다
+            </span>
           </div>
           <button
             type='submit'
-            className='mt-5 bg-[#3870e0] text-white px-4 py-[0.6rem] rounded-md focus:bg-[#3464c2] hover:bg-[#3464c2] box-shadow'
+            disabled={
+              email &&
+              password &&
+              repeatPassword &&
+              username &&
+              isChckedPrivacyPolicy
+                ? false
+                : true
+            }
+            className={`mt-6 px-4 py-[0.75rem] rounded-[0.425rem] box-shadow font-medium bg-[#eaeffe] ${
+              email &&
+              password &&
+              repeatPassword &&
+              username &&
+              isChckedPrivacyPolicy
+                ? 'text-[#5880f8]'
+                : 'text-[#9fb6fb]'
+            }`}
           >
             회원가입
           </button>


### PR DESCRIPTION
## 👀 이슈

resolve #15 

## 📌 개요

기존 로그인/회원가입 페이지 디자인을 시스템에 유사하도록
변경하고자 하였습니다.

## 👩‍💻 작업 사항

- 로그인 페이지 디자인 변경
- 회원가입 페이지 디자인 변경
- 개인정보처리방침 modal 컴포넌트 디자인 변경

## ✅ 참고 사항

- 기존 `로그인` 페이지 디자인 
<img width="1608" alt="Screenshot 2024-03-24 at 9 32 28 AM" src="https://github.com/cbnu-buddy/buddy-client/assets/56868605/6a4e8af3-fd8b-4cc9-bfce-b15283f7dfdc">

- 수정 후 `로그인 페이지 디자인 
<img width="1608" alt="Screenshot 2024-03-24 at 9 35 34 AM" src="https://github.com/cbnu-buddy/buddy-client/assets/56868605/dbf5213b-9fe4-4bfb-b455-535e0bf78084">

---

- 기존 `회원가입` 페이지 디자인
<img width="1608" alt="Screenshot 2024-03-24 at 9 32 31 AM" src="https://github.com/cbnu-buddy/buddy-client/assets/56868605/9bc837d5-b031-4508-94fd-e47153109749">

- 수정 후 `회원가입` 페이지 디자인
<img width="1608" alt="Screenshot 2024-03-24 at 9 35 37 AM" src="https://github.com/cbnu-buddy/buddy-client/assets/56868605/1a3b5997-ff8d-4f1a-b7f8-30efbd91fef8">