### PR TITLE
[feat]: 자주 묻는 질문 게시글 페이지 접근 시 param에 해당되는 탭 활성화 기능 추가 (#17)

### DIFF
--- a/app/faq/layout.tsx
+++ b/app/faq/layout.tsx
@@ -5,10 +5,26 @@ import magnifierImg from '@/public/images/magnifier.png';
 import phoneCallImg from '@/public/images/phone_call.png';
 import { faqTabNameStore } from '../store/faq/FaqTabName';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useEffect } from 'react';
 
 export default function Faq({ children }: { children: React.ReactNode }) {
   const faqTabName = faqTabNameStore((state: any) => state.tabName);
   const updateFaqTabName = faqTabNameStore((state: any) => state.updateTabName);
+
+  const params: any = useParams();
+  const faqId = parseInt(params.faqId);
+
+  useEffect(() => {
+    if (faqId >= 1 && faqId <= 7) updateFaqTabName('topQuestion');
+    else if (faqId >= 8 && faqId <= 13) updateFaqTabName('party');
+    else if (faqId >= 14 && faqId <= 20) updateFaqTabName('partyLeader');
+    else if (faqId >= 21 && faqId <= 27) updateFaqTabName('partyMember');
+    else if (faqId >= 28 && faqId <= 37)
+      updateFaqTabName('paymentAndAccumulation');
+    else if (faqId >= 38 && faqId <= 42) updateFaqTabName('couponAndPoint');
+    else if (faqId >= 43 && faqId <= 50) updateFaqTabName('useBuddy');
+  }, [faqId, updateFaqTabName]);
 
   return (
     <div>


### PR DESCRIPTION
## 👀 이슈

resolve #17 

## 📌 개요

기존에 자주 묻는 질문 게시글 페이지를 URL로 직접적으로 접근 시에
탭이 질문 TOP으로 설정되는 이슈가 있어서 param에 해당되는 탭이
활성화 되도록 하는 기능을 추가하였습니다.

## 👩‍💻 작업 사항

- `자주 묻는 질문` 게시글 페이지 접근 시 param에 해당되는 탭 활성화 기능 추가

## ✅ 참고 사항

없습니다