### PR TITLE
[fix] {나의 파티 목록 조회} API 엔드포인트 변경으로 인한 프론트 측 request URL 수정 #50

### DIFF
--- a/app/my-party/page.tsx
+++ b/app/my-party/page.tsx
@@ -16,7 +16,7 @@ import warningGrayImg from '@/public/images/warning_icon_gray.png';
 
 const fetchMyPartyInfo = ({ queryKey }: any) => {
   const planId = queryKey[1];
-  return axiosInstance.get(`/private/party/my-party`);
+  return axiosInstance.get(`/private/party/my`);
 };
 
 const getIconImg = (planId: number) => {


### PR DESCRIPTION
## 👀 이슈

resolve #50 

## 📌 개요

서버 측 `나의 파티 목록 조회` API 엔드포인트가 변경됨에 따라
기존 프론트 측에서 사용하던 `request URL`을 변경된 엔드포인트에 맞게
수정하였습니다.

## 👩‍💻 작업 사항

- {나의 파티 목록 조회} API 엔드포인트 변경으로 인한 프론트 측 request URL 수정

## ✅ 참고 사항

없습니다