### PR TITLE
[fix] Image 컴포넌트 legacy prop 마이그레이션 #63

### DIFF
--- a/app/community/components/entirePost/PostListItem.tsx
+++ b/app/community/components/entirePost/PostListItem.tsx
@@ -28,8 +28,7 @@ export default function PostListItem(props: TagPostListItemProps) {
               <Image
                 src='https://avatars.githubusercontent.com/u/119295431?v=4'
                 alt='profileImage'
-                layout='fill'
-                objectFit='cover'
+                fill
                 quality={100}
                 className='rounded-full'
               />
@@ -49,8 +48,7 @@ export default function PostListItem(props: TagPostListItemProps) {
             <Image
               src={testImg}
               alt='main_1Image'
-              layout='fill'
-              objectFit='cover'
+              fill
               quality={100}
               className='rounded-[0.275rem]'
             />

--- a/app/community/components/hotPost/HotPostListItem.tsx
+++ b/app/community/components/hotPost/HotPostListItem.tsx
@@ -30,8 +30,8 @@ export default function HotPostListItem(props: HotPostListItemProps) {
             <Image
               src={testImg}
               alt='main_1Image'
-              layout='fill' // 부모 요소에 맞추기 위해 fill 사용
-              objectFit='cover' // 이미지 비율 유지하며 부모 요소에 맞춤
+              fill
+              // 이미지 비율 유지하며 부모 요소에 맞춤
               quality={100}
               className='rounded-md'
             />

--- a/app/community/components/swiperBannerContents/Slide1.tsx
+++ b/app/community/components/swiperBannerContents/Slide1.tsx
@@ -17,8 +17,8 @@ export const Slide1: FC<Slide1Props> = ({ handlePrev, handleNext }) => {
       <Image
         src={communityBannerImg}
         alt='communityBannerImage'
-        layout='fill' // 부모 요소에 맞추기 위해 fill 사용
-        objectFit='cover' // 이미지 비율 유지하며 부모 요소에 맞춤
+        fill
+        // 이미지 비율 유지하며 부모 요소에 맞춤
         quality={100}
         className='rounded-md'
       />

--- a/app/community/components/swiperBannerContents/Slide2.tsx
+++ b/app/community/components/swiperBannerContents/Slide2.tsx
@@ -17,8 +17,8 @@ export const Slide2: FC<Slide2Props> = ({ handlePrev, handleNext }) => {
       <Image
         src={communityBannerImg2}
         alt='communityBannerImage2'
-        layout='fill' // 부모 요소에 맞추기 위해 fill 사용
-        objectFit='cover' // 이미지 비율 유지하며 부모 요소에 맞춤
+        fill
+        // 이미지 비율 유지하며 부모 요소에 맞춤
         quality={100}
         className='rounded-md'
       />

--- a/app/community/components/tagPost/TagPostListItem.tsx
+++ b/app/community/components/tagPost/TagPostListItem.tsx
@@ -28,8 +28,7 @@ export default function TagPostListItem(props: TagPostListItemProps) {
               <Image
                 src='https://avatars.githubusercontent.com/u/119295431?v=4'
                 alt='profileImage'
-                layout='fill'
-                objectFit='cover'
+                fill
                 quality={100}
                 className='rounded-full'
               />
@@ -49,8 +48,7 @@ export default function TagPostListItem(props: TagPostListItemProps) {
             <Image
               src={testImg}
               alt='main_1Image'
-              layout='fill'
-              objectFit='cover'
+              fill
               quality={100}
               className='rounded-[0.275rem]'
             />

--- a/app/community/feed/components/feedPost/FeedPostListItem.tsx
+++ b/app/community/feed/components/feedPost/FeedPostListItem.tsx
@@ -29,8 +29,7 @@ export default function FeedPostListItem(props: FeedPostListItemProps) {
                 <Image
                   src='https://avatars.githubusercontent.com/u/119295431?v=4'
                   alt='profileImage'
-                  layout='fill'
-                  objectFit='cover'
+                  fill
                   quality={100}
                   className='rounded-full'
                 />
@@ -55,8 +54,7 @@ export default function FeedPostListItem(props: FeedPostListItemProps) {
                 <Image
                   src={test2Img}
                   alt='main_1Image'
-                  layout='fill'
-                  objectFit='cover'
+                  fill
                   quality={100}
                   className='rounded-md'
                 />

--- a/app/community/post/[postId]/comment/[commentId]/components/ReplyListItem.tsx
+++ b/app/community/post/[postId]/comment/[commentId]/components/ReplyListItem.tsx
@@ -24,8 +24,7 @@ export default function ReplyListItem(props: ReplyListItemProps) {
               <Image
                 src={replyInfo.writer.profileImagePathUrl}
                 alt='profileImage'
-                layout='fill'
-                objectFit='cover'
+                fill
                 quality={100}
                 className='rounded-full'
               />

--- a/app/community/post/[postId]/comment/[commentId]/page.tsx
+++ b/app/community/post/[postId]/comment/[commentId]/page.tsx
@@ -123,8 +123,7 @@ export default function CommunityPostComment() {
                 <Image
                   src={commentInfo.writer.profileImagePathUrl}
                   alt='profileImage'
-                  layout='fill'
-                  objectFit='cover'
+                  fill
                   quality={100}
                   className='rounded-full'
                 />

--- a/app/community/post/[postId]/components/comment/CommentListItem.tsx
+++ b/app/community/post/[postId]/components/comment/CommentListItem.tsx
@@ -36,8 +36,7 @@ export default function CommentListItem(props: CommentListItemProps) {
             <Image
               src={commentInfo.writer.profileImagePathUrl}
               alt='profileImage'
-              layout='fill'
-              objectFit='cover'
+              fill
               quality={100}
               className='rounded-full'
             />

--- a/app/community/post/[postId]/components/comment/reply/ReplyListItem.tsx
+++ b/app/community/post/[postId]/components/comment/reply/ReplyListItem.tsx
@@ -24,8 +24,7 @@ export default function ReplyListItem(props: ReplyListItemProps) {
               <Image
                 src={replyInfo.writer.profileImagePathUrl}
                 alt='profileImage'
-                layout='fill'
-                objectFit='cover'
+                fill
                 quality={100}
                 className='rounded-full'
               />

--- a/app/community/post/[postId]/page.tsx
+++ b/app/community/post/[postId]/page.tsx
@@ -274,8 +274,7 @@ export default function CommunityPost(props: DefaultProps) {
                     <Image
                       src={resData.author.profileImagePathUrl}
                       alt='profileImage'
-                      layout='fill'
-                      objectFit='cover'
+                      fill
                       quality={100}
                       className='rounded-full'
                     />

--- a/app/community/search/components/hotPost/HotPostListItem.tsx
+++ b/app/community/search/components/hotPost/HotPostListItem.tsx
@@ -127,8 +127,8 @@ export default function HotPostListItem(props: HotPostListItemProps) {
             <Image
               src={testImg}
               alt='main_1Image'
-              layout='fill' // 부모 요소에 맞추기 위해 fill 사용
-              objectFit='cover' // 이미지 비율 유지하며 부모 요소에 맞춤
+              fill
+              // 이미지 비율 유지하며 부모 요소에 맞춤
               quality={100}
               className='rounded-md'
             />

--- a/app/community/search/components/relatedSearchPost/RelatedSearchPostListItem.tsx
+++ b/app/community/search/components/relatedSearchPost/RelatedSearchPostListItem.tsx
@@ -125,8 +125,8 @@ export default function RelatedSearchPostListItem(
             <Image
               src={testImg}
               alt='main_1Image'
-              layout='fill' // 부모 요소에 맞추기 위해 fill 사용
-              objectFit='cover' // 이미지 비율 유지하며 부모 요소에 맞춤
+              fill
+              // 이미지 비율 유지하며 부모 요소에 맞춤
               quality={100}
               className='rounded-md'
             />

--- a/app/community/search/components/swiperBannerContents/Slide1.tsx
+++ b/app/community/search/components/swiperBannerContents/Slide1.tsx
@@ -17,8 +17,8 @@ export const Slide1: FC<Slide1Props> = ({ handlePrev, handleNext }) => {
       <Image
         src={communitySearchBanner}
         alt='communitySearchBannerImage'
-        layout='fill' // 부모 요소에 맞추기 위해 fill 사용
-        objectFit='cover' // 이미지 비율 유지하며 부모 요소에 맞춤
+        fill
+        // 이미지 비율 유지하며 부모 요소에 맞춤
         quality={100}
         className='rounded-md'
       />

--- a/app/community/search/components/swiperBannerContents/Slide2.tsx
+++ b/app/community/search/components/swiperBannerContents/Slide2.tsx
@@ -17,8 +17,8 @@ export const Slide2: FC<Slide2Props> = ({ handlePrev, handleNext }) => {
       <Image
         src={communitySearchBanner2}
         alt='communitySearchBannerImage2'
-        layout='fill' // 부모 요소에 맞추기 위해 fill 사용
-        objectFit='cover' // 이미지 비율 유지하며 부모 요소에 맞춤
+        fill
+        // 이미지 비율 유지하며 부모 요소에 맞춤
         quality={100}
         className='rounded-md'
       />


### PR DESCRIPTION
## 👀 이슈

resolve #63 

## 📌 개요

프로젝트에서 이미지 표시를 위해 사용하는 `<Image>` 컴포넌트 내 `legacy prop`가 존재하여
프로젝트에서 사용하는 Next.js 버전에 맞는 prop으로 마이그레이션 하였습니다.

## 👩‍💻 작업 사항

- Image 컴포넌트 legacy prop 마이그레이션

## ✅ 참고 사항

없습니다