### PR TITLE
커뮤니티 게시글 상세 페이지 내 {태그 목록} 요소 추가

### DIFF
--- a/app/community/post/[postId]/page.tsx
+++ b/app/community/post/[postId]/page.tsx
@@ -298,7 +298,21 @@ export default function CommunityPost(props: DefaultProps) {
                 source={`<p>이건 버디 커뮤니티 게시글 본문 <strong>테스트 내용</strong>입니다.</p><p>&nbsp;</p><figure class=\"image\"><img src=\"https://swjudgeapi.cbnu.ac.kr/uploads/c24e87aa-a99d-479e-a134-c7f4554291cf.png\"></figure><p>&nbsp;</p><p>게시글 하단 내용도 포함</p>`}
               />
 
-              <div className='flex justify-between items-center'>
+              <div className='h-[2.5rem] flex items-center gap-x-2'>
+                {resData.tags.map((tagInfo, index) => (
+                  <Link
+                    href={`/community/search?tag=${tagInfo.tag}`}
+                    className='flex items-center min-h-6 h-auto leading-none text-xs text-start outline-none px-[0.2rem] bg-[#eee] rounded-[0.125rem] border border-[#eee] focus:bg-[#656565] focus:text-white hover:bg-[#656565] hover:text-white hover:border-[#656565]'
+                  >
+                    #
+                    <span className='ml-[0.1rem] text-inherit break-all'>
+                      {tagInfo.tag}
+                    </span>
+                  </Link>
+                ))}
+              </div>
+
+              <div className='mt-2 flex justify-between items-center'>
                 <div className='mt-1 flex gap-x-2 h-8'>
                   <div className='flex items-center gap-x-[0.15rem] bg-[#f2f4f6] text-[#4e5968] rounded-full px-3'>
                     <svg

--- a/app/community/post/[postId]/page.tsx
+++ b/app/community/post/[postId]/page.tsx
@@ -301,6 +301,7 @@ export default function CommunityPost(props: DefaultProps) {
               <div className='h-[2.5rem] flex items-center gap-x-2'>
                 {resData.tags.map((tagInfo, index) => (
                   <Link
+                    key={index}
                     href={`/community/search?tag=${tagInfo.tag}`}
                     className='flex items-center min-h-6 h-auto leading-none text-xs text-start outline-none px-[0.2rem] bg-[#eee] rounded-[0.125rem] border border-[#eee] focus:bg-[#656565] focus:text-white hover:bg-[#656565] hover:text-white hover:border-[#656565]'
                   >

--- a/utils/upload/uploadAdapter.js
+++ b/utils/upload/uploadAdapter.js
@@ -1,0 +1,18 @@
+export class UploadAdapter {
+  constructor(loader, uploadService) {
+    this.loader = loader;
+    this.uploadService = uploadService;
+  }
+
+  upload() {
+    return this.loader.file
+      .then((file) => this.uploadService.upload(file))
+      .then((response) => {
+        return { default: response.data.url };
+      })
+      .catch((error) => {
+        console.error(error);
+        throw error;
+      });
+  }
+}

--- a/utils/upload/uploadService.js
+++ b/utils/upload/uploadService.js
@@ -1,0 +1,16 @@
+import axiosInstance from '@/utils/axiosInstance';
+
+export class UploadService {
+  async upload(file) {
+    const formData = new FormData();
+    formData.append('upload', file);
+
+    const response = (await axiosInstance.post)('/private/upload', formData, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+
+    return response.data;
+  }
+}


### PR DESCRIPTION
resolve #70 

## Description

기존 **커뮤니티 게시글 상세** 페이지 내에 `태그 목록`이 표시되던 요소가
누락되어 해당 코드를 추가하고자 하였습니다.

- 추가된 **커뮤니티 게시글 상세 페이지** 내 `태그 목록` 요소

<img width="1009" alt="Screenshot 2024-09-05 at 10 53 03 AM" src="https://github.com/user-attachments/assets/3209784f-7ffd-4f2a-bc72-083e9833da22">